### PR TITLE
v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.10.0] - 2025-01-01
 ### Added
 - lsq configuration file to set user defaults instead of using flags on every run.
 


### PR DESCRIPTION
### Changed
- How the `d` flag operates. The full path must be specified when using this flag. Example: "~/Documents/Notes"
- `CONTRIBUTIONS.md` to be `CONTRIBUTING.md`
- `README.md`