### PR TITLE
Added the ability to append from STDIN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- The ability to paste from STDIN using `-A`.
 
 ## [1.0.0] - 2025-01-09
 ### Removed

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ lsq
 ## Usage
 ### Command Line Options
 - `-a`: Append text directly to the current journal page
+- `-A`: Append the contents of STDIN to the current journal page
 - `-d`: Specify main directory path. (example: `/home/jrswab/Documents/Notes`)
 - `-e`: Set editor to use while editing files. (Defaults to $EDITOR, then Vim if $EDITOR is not set)
 - `-f`: Search pages and aliases. Must be followed by a string.
@@ -87,6 +88,13 @@ lsq -f word -o
 ```
 This will search your pages for files containing "word" and open the first result in $EDITOR.
 If `-o` is not provided lsq will output all files which contain "word" to STDOUT.
+
+```bash
+cat ~/.zshrc | lsq -A
+```
+This will take the contents of your `~/.zshrc` file and append it to your current
+journal. This reads STDIN through to end-of-file, so be sure to `Ctrl-d` if your
+contents don't contain an end-of-file.
 
 ## Contributing
 For information on contributing to lsq check out [CONTRIBUTING.md](https://github.com/jrswab/lsq/blob/master/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ This will take the contents of your `~/.zshrc` file and append it to your curren
 journal. This reads STDIN through to end-of-file, so be sure to `Ctrl-d` if your
 contents don't contain an end-of-file.
 
+```bash
+run_long_batch_job |& lsq -A -p "long-job.$(date +%s).log"
+```
+This will run your long-running batch job, and it'll append the contents of STDIN
+and STDERR (note the pipe!) to a new page called `long-job.UNIX_TIMESTAMP.log`.
+
 ## Contributing
 For information on contributing to lsq check out [CONTRIBUTING.md](https://github.com/jrswab/lsq/blob/master/CONTRIBUTING.md).
 

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"io"
 	"path/filepath"
 	"strings"
 	"time"
@@ -20,6 +21,7 @@ func main() {
 	// File Path Override
 	lsqDirPath := flag.String("d", "", "The path to the Logseq directory to use.")
 
+	apndStdin := flag.Bool("A", false, "Append STDIN to the current journal page. This will not open $EDITOR.")
 	apnd := flag.String("a", "", "Append text to the current journal page. This will not open $EDITOR.")
 	editorType := flag.String("e", "", "The external editor to use. Will use $EDITOR when blank or omitted.")
 	cliSearch := flag.String("f", "", "Search by file name in your pages directory.")
@@ -34,6 +36,15 @@ func main() {
 	if *version {
 		fmt.Println(semVer)
 		os.Exit(0)
+	}
+
+	if *apndStdin {
+		content, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error reading STDIN: %v\n", err)
+			os.Exit(1)
+		}
+		*apnd = string(content)
 	}
 
 	cfg, err := config.Load()


### PR DESCRIPTION
- Added a new flag, `-A`, which reads STDIN through EOF, and then pastes it
- This is compatible with the way that `-a` works, it just uses STDIN instead of a string argument

This closes #49.