### PR TITLE
expand ~ and environment variables in directory paths

### DIFF
--- a/main.go
+++ b/main.go
@@ -96,7 +96,12 @@ func main() {
 
 	// When this flag is used override the config.
 	if *lsqDirPath != "" {
-		cfg.DirPath = *lsqDirPath
+		expanded, expandErr := config.ExpandPath(*lsqDirPath)
+		if expandErr != nil {
+			log.Printf("Error expanding directory path: %v\n", expandErr)
+			os.Exit(1)
+		}
+		cfg.DirPath = expanded
 		cfg.JournalsDir = filepath.Join(cfg.DirPath, "journals")
 		cfg.PagesDir = filepath.Join(cfg.DirPath, "pages")
 	}


### PR DESCRIPTION
Resolve #63 users can now use ~/path and $VAR/${VAR} in the :directory config value and the -d CLI flag instead of requiring a fully-qualified absolute path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Configuration paths now support tilde (~) expansion for the user's home directory
  * Environment variables can be used within directory path settings
  * Works with both configuration files and command-line directory overrides

<!-- end of auto-generated comment: release notes by coderabbit.ai -->