### PR TITLE
ISS-69 - Add -J Flag For Full Journal Overview

### DIFF
--- a/main.go
+++ b/main.go
@@ -72,6 +72,7 @@ func main() {
 	specDate := flag.String("s", "", "Open a specific journal. Use yyyy-MM-dd after the flag.")
 	version := flag.Bool("v", false, "Display current lsq version")
 	yesterday := flag.Bool("y", false, "Open yesterday's journal page")
+	journalOverview := flag.Bool("j", false, "Print full journal overview to STDOUT via pager (newest first, skipping empty dates).")
 
 	flag.Parse()
 
@@ -226,6 +227,23 @@ func main() {
 	if err != nil {
 		log.Printf("Error setting journal path: %v\n", err)
 		os.Exit(1)
+	}
+
+	// Print full journal overview to STDOUT via pager (newest first, skipping empty dates).
+	if *journalOverview {
+		pw, cleanup, err := system.LoadPager()
+		if err != nil {
+			log.Printf("Error loading pager: %v\n", err)
+			os.Exit(1)
+		}
+		defer cleanup()
+		if err := system.PrintJournalOverview(pw, cfg, cfg.JournalsDir); err != nil {
+			log.Printf("Error printing journal overview: %v\n", err)
+			os.Exit(1)
+		}
+		// pw must be closed before cleanup runs so the pager receives EOF
+		pw.Close()
+		return
 	}
 
 	// Print journal content to STDOUT and exit.

--- a/system/exec.go
+++ b/system/exec.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 )
@@ -29,4 +30,61 @@ func LoadEditor(editor, path string) {
 		fmt.Printf("Error opening editor: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+// nopCloser wraps an io.Writer with a no-op Close method
+type nopCloser struct {
+	io.Writer
+}
+
+func (nopCloser) Close() error { return nil }
+
+// LoadPager returns a writer that writes to a pager (less/more), or stdout if no pager is available.
+// The caller must call the returned cleanup function after writing all content.
+func LoadPager() (io.WriteCloser, func(), error) {
+	// Resolve pager command
+	pager := os.Getenv("PAGER")
+
+	if pager == "" {
+		if path, err := exec.LookPath("less"); err == nil {
+			pager = path
+		} else if path, err := exec.LookPath("more"); err == nil {
+			pager = path
+		}
+	}
+
+	// If no pager found, fall back to stdout
+	if pager == "" {
+		return nopCloser{os.Stdout}, func() {}, nil
+	}
+
+	// Create pipe for pager subprocess
+	readPipe, writePipe, err := os.Pipe()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Setup pager command
+	cmd := exec.Command(pager)
+	cmd.Stdin = readPipe
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	// Start the pager
+	if err := cmd.Start(); err != nil {
+		readPipe.Close()
+		writePipe.Close()
+		return nil, nil, err
+	}
+
+	// Close read end in parent process (pager has it now)
+	readPipe.Close()
+
+	// Create cleanup function
+	cleanup := func() {
+		// Wait for pager to finish (ignore non-zero exit)
+		cmd.Wait()
+	}
+
+	return writePipe, cleanup, nil
 }

--- a/system/exec_test.go
+++ b/system/exec_test.go
@@ -1,0 +1,159 @@
+package system_test
+
+import (
+	"testing"
+
+	"github.com/jrswab/lsq/system"
+)
+
+func TestLoadPager_PagerSetToCat(t *testing.T) {
+	t.Setenv("PAGER", "cat")
+
+	writer, cleanup, err := system.LoadPager()
+	if err != nil {
+		t.Fatalf("LoadPager() returned error: %v", err)
+	}
+	if writer == nil {
+		t.Fatal("LoadPager() returned nil writer")
+	}
+	defer cleanup()
+
+	// Write some data
+	testData := []byte("hello world\n")
+	n, err := writer.Write(testData)
+	if err != nil {
+		t.Fatalf("Write() returned error: %v", err)
+	}
+	if n != len(testData) {
+		t.Fatalf("Write() wrote %d bytes, expected %d", n, len(testData))
+	}
+
+	// Cleanup should not panic
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("cleanup() panicked: %v", r)
+			}
+		}()
+		// Must close writer before cleanup to signal EOF to pager
+		writer.Close()
+		cleanup()
+	}()
+}
+
+func TestLoadPager_NoPagerAvailable(t *testing.T) {
+	// Create a temp directory with no executables
+	tempDir := t.TempDir()
+
+	// Set PATH to empty temp dir and unset PAGER
+	t.Setenv("PATH", tempDir)
+	t.Setenv("PAGER", "")
+
+	writer, cleanup, err := system.LoadPager()
+	if err != nil {
+		t.Fatalf("LoadPager() returned error when no pager available: %v", err)
+	}
+	if writer == nil {
+		t.Fatal("LoadPager() returned nil writer when no pager available")
+	}
+
+	// Cleanup should be a no-op and not block
+	done := make(chan struct{})
+	go func() {
+		cleanup()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success - cleanup completed without blocking
+	case <-t.Context().Done():
+		t.Fatal("cleanup() blocked when no pager available")
+	}
+
+	// Writer should still accept writes without error
+	testData := []byte("test data\n")
+	_, writeErr := writer.Write(testData)
+	// Write to a no-op writer should succeed (bytes written to nowhere)
+	if writeErr != nil {
+		t.Fatalf("Write() returned error when no pager available: %v", writeErr)
+	}
+}
+
+func TestLoadPager_WriteThenClose(t *testing.T) {
+	t.Setenv("PAGER", "cat")
+
+	writer, cleanup, err := system.LoadPager()
+	if err != nil {
+		t.Fatalf("LoadPager() returned error: %v", err)
+	}
+	if writer == nil {
+		t.Fatal("LoadPager() returned nil writer")
+	}
+	defer cleanup()
+
+	// Write some data
+	testData := []byte("test data for close\n")
+	_, err = writer.Write(testData)
+	if err != nil {
+		t.Fatalf("Write() returned error: %v", err)
+	}
+
+	// Close should not return error
+	// The writer is an io.WriteCloser, so it has a Close() method
+	if closeErr := writer.Close(); closeErr != nil {
+		t.Fatalf("Close() returned error: %v", closeErr)
+	}
+}
+
+func TestLoadPager_WrittenBytesNotLost(t *testing.T) {
+	// This test uses a custom writer to verify bytes are not lost
+	t.Setenv("PAGER", "cat")
+
+	writer, cleanup, err := system.LoadPager()
+	if err != nil {
+		t.Fatalf("LoadPager() returned error: %v", err)
+	}
+	if writer == nil {
+		t.Fatal("LoadPager() returned nil writer")
+	}
+	defer cleanup()
+
+	// Write multiple chunks
+	chunks := [][]byte{
+		[]byte("first chunk\n"),
+		[]byte("second chunk\n"),
+		[]byte("third chunk\n"),
+	}
+
+	var totalWritten int
+	for _, chunk := range chunks {
+		n, err := writer.Write(chunk)
+		if err != nil {
+			t.Fatalf("Write() returned error: %v", err)
+		}
+		totalWritten += n
+	}
+
+	expectedTotal := 0
+	for _, chunk := range chunks {
+		expectedTotal += len(chunk)
+	}
+
+	if totalWritten != expectedTotal {
+		t.Fatalf("Total bytes written %d does not match expected %d", totalWritten, expectedTotal)
+	}
+
+	// Verify we can still write after previous writes
+	finalChunk := []byte("final chunk\n")
+	n, err := writer.Write(finalChunk)
+	if err != nil {
+		t.Fatalf("Write() after previous writes returned error: %v", err)
+	}
+	if n != len(finalChunk) {
+		t.Fatalf("Write() after previous writes wrote %d bytes, expected %d", n, len(finalChunk))
+	}
+
+	// Must close writer before cleanup to signal EOF to pager
+	writer.Close()
+}

--- a/system/journal.go
+++ b/system/journal.go
@@ -1,12 +1,15 @@
 package system
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -106,4 +109,139 @@ func AppendToFile(path, content string, indent int) error {
 	// Write data to the file
 	_, err = file.WriteString(bc)
 	return err
+}
+
+// isJournalEmpty checks if journal content is effectively empty
+// (only whitespace, newlines, or dash placeholders)
+func isJournalEmpty(content []byte) bool {
+	if len(content) == 0 {
+		return true
+	}
+
+	// Pattern: dash followed by optional whitespace, end of string
+	re := regexp.MustCompile(`^-\s*$`)
+
+	// Split content into lines and check each non-blank line
+	lines := bytes.Split(content, []byte{'\n'})
+	for _, line := range lines {
+		// Check if line is blank (only whitespace)
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		// Non-blank line must match the placeholder pattern
+		if !re.Match(line) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// PrintJournalOverview prints an overview of all non-empty journal entries
+// in reverse chronological order (newest first).
+func PrintJournalOverview(w io.Writer, cfg *config.Config, journalsDir string) error {
+	// Read the journals directory
+	entries, err := os.ReadDir(journalsDir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("journals directory does not exist: %w", err)
+		}
+		return fmt.Errorf("error reading journals directory: %w", err)
+	}
+
+	// Determine expected file extension
+	extension := ".md"
+	if strings.EqualFold(cfg.FileType, "Org") {
+		extension = ".org"
+	}
+
+	// Parse date format from config
+	dateFormat := config.ConvertDateFormat(cfg.FileFmt)
+
+	// Type to hold parsed journal entries
+	type journalEntry struct {
+		date    time.Time
+		path    string
+		content string
+	}
+
+	var journals []journalEntry
+
+	// Process each entry in the directory
+	for _, entry := range entries {
+		// Skip directories
+		if entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+
+		// Check if file has the correct extension
+		if !strings.HasSuffix(name, extension) {
+			continue
+		}
+
+		// Remove extension to get the date string
+		dateStr := strings.TrimSuffix(name, extension)
+
+		// Parse the date in UTC to ensure consistent weekday names
+		date, err := time.ParseInLocation(dateFormat, dateStr, time.UTC)
+		if err != nil {
+			// Silently skip files that cannot be parsed as dates
+			continue
+		}
+
+		// Read file content
+		path := filepath.Join(journalsDir, name)
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("error reading file %s: %w", name, err)
+		}
+
+		// Skip empty journals
+		if isJournalEmpty(content) {
+			continue
+		}
+
+		journals = append(journals, journalEntry{
+			date:    date,
+			path:    path,
+			content: string(content),
+		})
+	}
+
+	// Sort in reverse chronological order (newest first)
+	sort.Slice(journals, func(i, j int) bool {
+		return journals[i].date.After(journals[j].date)
+	})
+
+	// Write output for each journal
+	for _, journal := range journals {
+		// Write header line: date + day + 65 U+2500 chars
+		header := journal.date.Format("2006-01-02") + " " +
+			journal.date.Format("Mon") + " " +
+			strings.Repeat("─", 65) + "\n"
+		if _, err := w.Write([]byte(header)); err != nil {
+			return fmt.Errorf("error writing header: %w", err)
+		}
+
+		// Write content
+		if _, err := w.Write([]byte(journal.content)); err != nil {
+			return fmt.Errorf("error writing content: %w", err)
+		}
+
+		// Write separator: if content ends with \n, write one more \n for blank line;
+		// otherwise write \n\n to add newline after content plus blank separator
+		if strings.HasSuffix(journal.content, "\n") {
+			if _, err := w.Write([]byte("\n")); err != nil {
+				return fmt.Errorf("error writing separator: %w", err)
+			}
+		} else {
+			if _, err := w.Write([]byte("\n\n")); err != nil {
+				return fmt.Errorf("error writing separator: %w", err)
+			}
+		}
+	}
+
+	return nil
 }

--- a/system/journal_empty_test.go
+++ b/system/journal_empty_test.go
@@ -1,0 +1,124 @@
+package system
+
+import (
+	"testing"
+)
+
+func TestIsJournalEmpty(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  []byte
+		expected bool
+	}{
+		{
+			name:     "zero-length input",
+			content:  []byte(""),
+			expected: true,
+		},
+		{
+			name:     "only newlines",
+			content:  []byte("\n\n\n"),
+			expected: true,
+		},
+		{
+			name:     "only whitespace",
+			content:  []byte("   \t\n  \n"),
+			expected: true,
+		},
+		{
+			name:     "only whitespace and tabs",
+			content:  []byte("\t  \t  \n"),
+			expected: true,
+		},
+		{
+			name:     "single placeholder with space",
+			content:  []byte("- \n"),
+			expected: true,
+		},
+		{
+			name:     "single placeholder without space",
+			content:  []byte("-\n"),
+			expected: true,
+		},
+		{
+			name:     "multiple placeholders",
+			content:  []byte("- \n\n- \n"),
+			expected: true,
+		},
+		{
+			name:     "placeholder with trailing whitespace",
+			content:  []byte("-   \n"),
+			expected: true,
+		},
+		{
+			name:     "blank lines and placeholders only",
+			content:  []byte("\n- \n\n-   \n\n"),
+			expected: true,
+		},
+		{
+			name:     "actual journal entry",
+			content:  []byte("- actual entry\n"),
+			expected: false,
+		},
+		{
+			name:     "actual entry with no trailing newline",
+			content:  []byte("- actual entry"),
+			expected: false,
+		},
+		{
+			name:     "mix of placeholders and real content",
+			content:  []byte("- \n\n- actual entry\n"),
+			expected: false,
+		},
+		{
+			name:     "real content with blank lines",
+			content:  []byte("\n\n- real content here\n\n"),
+			expected: false,
+		},
+		{
+			name:     "placeholder then real then blank",
+			content:  []byte("- \n- real line\n\n"),
+			expected: false,
+		},
+		{
+			name:     "unicode content",
+			content:  []byte("- 测试 Test テスト\n"),
+			expected: false,
+		},
+		{
+			name:     "unicode only on line",
+			content:  []byte("- 日本語\n"),
+			expected: false,
+		},
+		{
+			name:     "empty bullet followed by unicode",
+			content:  []byte("- \n- 日本語\n"),
+			expected: false,
+		},
+		{
+			name:     "dash at start with content",
+			content:  []byte("- not empty\n"),
+			expected: false,
+		},
+		{
+			name:     "dash followed by tab then content",
+			content:  []byte("-\tcontent\n"),
+			expected: false,
+		},
+		{
+			name:     "multiple dashes in content",
+			content:  []byte("- item - with - dashes\n"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isJournalEmpty(tt.content)
+			if result != tt.expected {
+				t.Errorf("isJournalEmpty(%q) = %v, want %v",
+					tt.content, result, tt.expected)
+			}
+		})
+	}
+}

--- a/system/journal_test.go
+++ b/system/journal_test.go
@@ -1,6 +1,7 @@
 package system_test
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -393,4 +394,231 @@ func TestAppendToFile(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPrintJournalOverview(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupFiles  map[string]string // filename -> content (empty string = 0-byte file)
+		setupDirs   []string          // subdirectories to create
+		fileType    string            // "Markdown" or "Org"
+		journalsDir string            // override directory path (empty = use temp dir)
+		wantErr     bool
+		wantOutput  string
+	}{
+		{
+			name:        "directory does not exist",
+			journalsDir: "/nonexistent/path/to/journals",
+			fileType:    "Markdown",
+			setupFiles:  nil,
+			wantErr:     true,
+			wantOutput:  "",
+		},
+		{
+			name:       "empty directory",
+			setupFiles: map[string]string{},
+			fileType:   "Markdown",
+			wantErr:    false,
+			wantOutput: "",
+		},
+		{
+			name: "all files are empty",
+			setupFiles: map[string]string{
+				"2006_01_02.md": "",
+				"2006_01_03.md": "",
+			},
+			fileType:   "Markdown",
+			wantErr:    false,
+			wantOutput: "",
+		},
+		{
+			name: "single non-empty md file",
+			setupFiles: map[string]string{
+				"2006_01_02.md": "- Journal entry 1\n- Journal entry 2\n",
+			},
+			fileType: "Markdown",
+			wantErr:  false,
+			wantOutput: "2006-01-02 Mon " + strings.Repeat("─", 65) + "\n" +
+				"- Journal entry 1\n- Journal entry 2\n\n",
+		},
+		{
+			name: "multiple non-empty md files reverse chronological order",
+			setupFiles: map[string]string{
+				"2006_01_02.md": "Older journal content",
+				"2006_01_04.md": "Newest journal content",
+				"2006_01_03.md": "Middle journal content",
+			},
+			fileType: "Markdown",
+			wantErr:  false,
+			wantOutput: "2006-01-04 Wed " + strings.Repeat("─", 65) + "\n" +
+				"Newest journal content\n\n" +
+				"2006-01-03 Tue " + strings.Repeat("─", 65) + "\n" +
+				"Middle journal content\n\n" +
+				"2006-01-02 Mon " + strings.Repeat("─", 65) + "\n" +
+				"Older journal content\n\n",
+		},
+		{
+			name: "mix of empty and non-empty files",
+			setupFiles: map[string]string{
+				"2006_01_02.md": "",
+				"2006_01_03.md": "Has content",
+				"2006_01_04.md": "",
+			},
+			fileType: "Markdown",
+			wantErr:  false,
+			wantOutput: "2006-01-03 Tue " + strings.Repeat("─", 65) + "\n" +
+				"Has content\n\n",
+		},
+		{
+			name: "file name cannot be parsed as date",
+			setupFiles: map[string]string{
+				"2006_01_02.md":   "Valid date",
+				"invalid-date.md": "Invalid date content",
+			},
+			fileType: "Markdown",
+			wantErr:  false,
+			wantOutput: "2006-01-02 Mon " + strings.Repeat("─", 65) + "\n" +
+				"Valid date\n\n",
+		},
+		{
+			name: "non-journal file wrong extension",
+			setupFiles: map[string]string{
+				"2006_01_02.md":  "Valid journal",
+				"2006_01_03.txt": "Text file content",
+				"2006_01_04.org": "Org file content",
+			},
+			fileType: "Markdown",
+			wantErr:  false,
+			wantOutput: "2006-01-02 Mon " + strings.Repeat("─", 65) + "\n" +
+				"Valid journal\n\n",
+		},
+		{
+			name: "subdirectory inside journals dir",
+			setupFiles: map[string]string{
+				"2006_01_02.md": "Valid journal",
+			},
+			setupDirs: []string{"subdir"},
+			fileType:  "Markdown",
+			wantErr:   false,
+			wantOutput: "2006-01-02 Mon " + strings.Repeat("─", 65) + "\n" +
+				"Valid journal\n\n",
+		},
+		{
+			name: "file content without trailing newline",
+			setupFiles: map[string]string{
+				"2006_01_02.md": "Content without newline",
+			},
+			fileType: "Markdown",
+			wantErr:  false,
+			wantOutput: "2006-01-02 Mon " + strings.Repeat("─", 65) + "\n" +
+				"Content without newline\n\n",
+		},
+		{
+			name: "unicode content in file",
+			setupFiles: map[string]string{
+				"2006_01_02.md": "测试 Test テスト 🎉",
+			},
+			fileType: "Markdown",
+			wantErr:  false,
+			wantOutput: "2006-01-02 Mon " + strings.Repeat("─", 65) + "\n" +
+				"测试 Test テスト 🎉\n\n",
+		},
+		{
+			name: "org file type config",
+			setupFiles: map[string]string{
+				"2006_01_02.md":  "Markdown file ignored",
+				"2006_01_03.org": "Org file content",
+				"2006_01_04.md":  "Another md ignored",
+				"2006_01_05.org": "Another org content",
+			},
+			fileType: "Org",
+			wantErr:  false,
+			wantOutput: "2006-01-05 Thu " + strings.Repeat("─", 65) + "\n" +
+				"Another org content\n\n" +
+				"2006-01-03 Tue " + strings.Repeat("─", 65) + "\n" +
+				"Org file content\n\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var journalsDir string
+			if tt.journalsDir != "" {
+				journalsDir = tt.journalsDir
+			} else {
+				journalsDir = t.TempDir()
+
+				// Create subdirectories
+				for _, dir := range tt.setupDirs {
+					err := os.MkdirAll(filepath.Join(journalsDir, dir), 0755)
+					if err != nil {
+						t.Fatalf("Failed to create subdirectory: %v", err)
+					}
+				}
+
+				// Create files
+				for filename, content := range tt.setupFiles {
+					path := filepath.Join(journalsDir, filename)
+					err := os.WriteFile(path, []byte(content), 0644)
+					if err != nil {
+						t.Fatalf("Failed to write test file %s: %v", filename, err)
+					}
+				}
+			}
+
+			cfg := &config.Config{
+				FileType: tt.fileType,
+				FileFmt:  "yyyy_MM_dd",
+			}
+
+			var buf bytes.Buffer
+			err := system.PrintJournalOverview(&buf, cfg, journalsDir)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("PrintJournalOverview() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if got := buf.String(); got != tt.wantOutput {
+				t.Errorf("PrintJournalOverview() output:\n%q\nwant:\n%q", got, tt.wantOutput)
+			}
+		})
+	}
+
+	// Header format assertion test - specific check for exact format
+	t.Run("header format assertion", func(t *testing.T) {
+		journalsDir := t.TempDir()
+
+		// 2006-01-02 is a Monday
+		cfg := &config.Config{
+			FileType: "Markdown",
+			FileFmt:  "yyyy_MM_dd",
+		}
+
+		err := os.WriteFile(filepath.Join(journalsDir, "2006_01_02.md"), []byte("test content"), 0644)
+		if err != nil {
+			t.Fatalf("Failed to write test file: %v", err)
+		}
+
+		var buf bytes.Buffer
+		err = system.PrintJournalOverview(&buf, cfg, journalsDir)
+		if err != nil {
+			t.Fatalf("PrintJournalOverview() error = %v", err)
+		}
+
+		// Expected header: 15 chars (date + day) + 65 U+2500 chars + newline
+		expectedHeader := "2006-01-02 Mon " + strings.Repeat("─", 65) + "\n"
+		got := buf.String()
+
+		if !strings.HasPrefix(got, expectedHeader) {
+			t.Errorf("Header format mismatch.\nGot prefix: %q\nWant:       %q", got[:min(len(got), len(expectedHeader))], expectedHeader)
+		}
+	})
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR implements a new `-J` flag for displaying a full journal overview. The feature integrates with the system's pager (configured via `PAGER` environment variable or defaults to `less`/`more`) to provide an aggregated view of all journal entries in reverse chronological order, while filtering out empty journal files and respecting the configured file format.

## Changelog

### Added
- New `-j` CLI flag to load and display a full journal overview via system pager
- `LoadPager()` function to resolve and initialize system pager with fallback support (`PAGER` env var → `less` → `more` → stdout)
- `PrintJournalOverview()` function to aggregate, filter, and output journal entries sorted by date in descending order
- `isJournalEmpty()` helper function to identify empty journals (containing only whitespace or placeholder dashes)
- Comprehensive test coverage for `LoadPager()`, `PrintJournalOverview()`, and `isJournalEmpty()` including edge cases for missing pagers, empty journals, Unicode content, and reverse chronological ordering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->