### PR TITLE
make -a/-A the default.  Add -E for edit mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- **Breaking:** Appending to the journal is now the default behavior. Running `lsq` without flags will append a journal entry instead of opening an editor.
+- **Breaking:** Append mode is now the default when content is provided (via arguments, `-a`/`-A`, or STDIN). Running `lsq` with no flags and no content opens the editor (equivalent to `-E`).
 - Added `-E` flag to enter edit mode (open the journal/page in your editor).
 - `-a` and `-A` flags no longer require explicit use to append; append mode is now the default.
 - `-i` flag no longer requires `-a` or `-A`; it is compatible with the default append mode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- **Breaking:** Appending to the journal is now the default behavior. Running `lsq` without flags will append a journal entry instead of opening an editor.
+- Added `-E` flag to enter edit mode (open the journal/page in your editor).
+- `-a` and `-A` flags no longer require explicit use to append; append mode is now the default.
+- `-i` flag no longer requires `-a` or `-A`; it is compatible with the default append mode.
 
 ## [1.5.0] - 2026-02-24
 ### Added

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ go install github.com/jrswab/lsq@latest
 ```bash
 lsq
 ```
+This will append a journal entry for today's date. Use `lsq -E` to open the editor.
 
 ## Usage
 ### Command Line Options
@@ -45,8 +46,9 @@ lsq
 - `-c`: Print journal or page content to STDOUT instead of opening an editor.
 - `-d`: Specify main directory path. Supports `~` and environment variables. (example: `~/Documents/Notes`)
 - `-e`: Set editor to use while editing files. (Defaults to $EDITOR, then Vim if $EDITOR is not set)
+- `-E`: Open the journal or page in your editor for editing (edit mode). Use `-E` to enter edit mode instead of the default append mode.
 - `-f`: Search pages and aliases. Must be followed by a string.
-- `-i`: Set the indentation level (number of tabs) for appended text. Requires `-a` or `-A`.
+- `-i`: Set the indentation level (number of tabs) for appended text.
 - `-n`: Number of days ago to target for the journal entry. (example: `-n 3` targets the journal from 3 days ago)
 - `-o`: Automatically open the first result from the search.
 - `-p`: Open a specific page from the pages directory.
@@ -84,7 +86,12 @@ The configuration file will override any lsq defaults which are defined. If a CL
 ```bash
 lsq
 ```
-This opens today's journal in your default editor ($EDITOR environment variable).
+This appends an entry to today's journal. No editor is opened—your note is captured immediately.
+
+```bash
+lsq -E
+```
+This opens today's journal in your default editor ($EDITOR environment variable) for editing.
 If no editor is defined in $EDITOR, then `Vim` will be used.
 
 ```bash
@@ -127,7 +134,8 @@ This prints the journal from 3 days ago to STDOUT.
 lsq -a "sub-item text" -i 1
 ```
 This appends text as an indented bullet (one tab level deep), creating a nested
-list item in Logseq. Use `-i 2` for two levels deep, and so on.
+list item in Logseq. Use `-i 2` for two levels deep, and so on. Note: `-i` cannot
+be used together with edit mode (`-E`).
 
 ## Contributing
 For information on contributing to lsq check out [CONTRIBUTING.md](https://github.com/jrswab/lsq/blob/master/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ go install github.com/jrswab/lsq@latest
 ```bash
 lsq
 ```
-This will append a journal entry for today's date. Use `lsq -E` to open the editor.
+This will open today's journal in your default editor for editing. Use `lsq -a "text"` to append without opening an editor.
 
 ## Usage
 ### Command Line Options
@@ -46,7 +46,7 @@ This will append a journal entry for today's date. Use `lsq -E` to open the edit
 - `-c`: Print journal or page content to STDOUT instead of opening an editor.
 - `-d`: Specify main directory path. Supports `~` and environment variables. (example: `~/Documents/Notes`)
 - `-e`: Set editor to use while editing files. (Defaults to $EDITOR, then Vim if $EDITOR is not set)
-- `-E`: Open the journal or page in your editor for editing (edit mode). Use `-E` to enter edit mode instead of the default append mode.
+- `-E`: Open the journal or page in your editor for editing (edit mode). Explicitly enable edit mode; edit mode is the default when no content is provided.
 - `-f`: Search pages and aliases. Must be followed by a string.
 - `-i`: Set the indentation level (number of tabs) for appended text.
 - `-n`: Number of days ago to target for the journal entry. (example: `-n 3` targets the journal from 3 days ago)
@@ -86,7 +86,7 @@ The configuration file will override any lsq defaults which are defined. If a CL
 ```bash
 lsq
 ```
-This appends an entry to today's journal. No editor is opened—your note is captured immediately.
+This opens today's journal in your default editor for editing. Use `lsq -a "text"` to append without opening an editor.
 
 ```bash
 lsq -E

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 	"github.com/jrswab/lsq/trie"
 )
 
-const semVer string = "1.4.0"
+const semVer string = "1.6.0"
 
 // Search regex pattern in given file, print matching lines
 func searchInFile(filePath string, pattern *regexp.Regexp) error {
@@ -59,12 +59,12 @@ func main() {
 	// File Path Override
 	lsqDirPath := flag.String("d", "", "The path to the Logseq directory to use.")
 
-	apndStdin := flag.Bool("A", false, "Append STDIN to the current journal page. This will not open $EDITOR.")
-	apnd := flag.String("a", "", "Append text to the current journal page. This will not open $EDITOR.")
+	apndStdin := flag.Bool("A", false, "Append STDIN to the current journal page.")
+	apnd := flag.String("a", "", "Append text to the current journal page.")
 	catFile := flag.Bool("c", false, "Print journal or page content to STDOUT instead of opening an editor.")
 	editorType := flag.String("e", "", "The external editor to use. Will use $EDITOR when blank or omitted.")
 	cliSearch := flag.String("f", "", "Search by file name in your pages directory.")
-	indent := flag.Int("i", 0, "Absolute indentation level (number of tab characters) for appended text. Requires -a or -A.")
+	indent := flag.Int("i", 0, "Absolute indentation level (number of tab characters) for appended text.")
 	daysAgo := flag.Int("n", 0, "Number of days ago to target for the journal entry.")
 	openFirstResult := flag.Bool("o", false, "Open the first result from search automatically.")
 	pageToOpen := flag.String("p", "", "Open a specific page from the pages directory. Must be a file name with extension.")
@@ -72,6 +72,7 @@ func main() {
 	specDate := flag.String("s", "", "Open a specific journal. Use yyyy-MM-dd after the flag.")
 	version := flag.Bool("v", false, "Display current lsq version")
 	yesterday := flag.Bool("y", false, "Open yesterday's journal page")
+	editMode := flag.Bool("E", false, "Open the journal page in your editor for editing (edit mode).")
 
 	flag.Parse()
 
@@ -90,11 +91,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	if *indent > 0 && *apnd == "" && !*apndStdin {
-		fmt.Fprintln(os.Stderr, "Error: -i requires -a or -A")
+	if *indent > 0 && *editMode {
+		fmt.Fprintln(os.Stderr, "Error: -i is incompatible with edit mode (-E). Use -a with -i for indented appending.")
 		os.Exit(1)
 	}
 
+	// Read STDIN when -A is explicitly used
 	if *apndStdin {
 		content, err := io.ReadAll(os.Stdin)
 		if err != nil {
@@ -102,6 +104,35 @@ func main() {
 			os.Exit(1)
 		}
 		*apnd = string(content)
+	}
+
+	// Read STDIN when piped (not a terminal), even without -A flag.
+	// Only read STDIN if no content was already provided by -a or -A.
+	if *apnd == "" {
+		stat, err := os.Stdin.Stat()
+		if err == nil && (stat.Mode()&os.ModeCharDevice) == 0 {
+			content, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error reading STDIN: %v\n", err)
+				os.Exit(1)
+			}
+			if string(content) != "" {
+				*apnd = string(content)
+			}
+		}
+	}
+
+	// Collect positional arguments (free args) into apnd if no -a or -A was used
+	if *apnd == "" {
+		args := flag.Args()
+		if len(args) > 0 {
+			*apnd = strings.Join(args, " ")
+		}
+	}
+
+	// When called with no flags and no content, default to edit mode (equivalent to -E)
+	if flag.NFlag() == 0 && *apnd == "" {
+		*editMode = true
 	}
 
 	cfg, err := config.Load()
@@ -143,11 +174,14 @@ func main() {
 				log.Printf("Error appending data to file: %v\n", err)
 				os.Exit(1)
 			}
-			// Don't open $EDITOR when append flag is used.
+			// Don't open $EDITOR when appending.
 			return
 		}
 
-		// Open page in default editor if specified:
+		// Open page in default editor only in edit mode.
+		if !*editMode {
+			return
+		}
 		system.LoadEditor(*editorType, pagePath)
 		return
 	}
@@ -237,14 +271,14 @@ func main() {
 		return
 	}
 
-	if *apnd != "" {
+	if !*editMode {
 		err := system.AppendToFile(journalPath, *apnd, *indent)
 		if err != nil {
 			log.Printf("Error appending data to file: %v\n", err)
 			os.Exit(1)
 		}
 
-		// Don't open $EDITOR  when append flag is used.
+		// Don't open $EDITOR  when in append (note) mode.
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -55,6 +55,18 @@ func searchInDirectory(directory string, pattern *regexp.Regexp) error {
 	})
 }
 
+// hasSelectorFlag reports whether any "selector" flags are explicitly set.
+// Selectors choose *which* resource to operate on, not *how* to operate.
+func hasSelectorFlag() bool {
+	selected := false
+	flag.CommandLine.Visit(func(f *flag.Flag) {
+		if f.Name == "n" || f.Name == "y" || f.Name == "s" || f.Name == "p" {
+			selected = true
+		}
+	})
+	return selected
+}
+
 func main() {
 	// File Path Override
 	lsqDirPath := flag.String("d", "", "The path to the Logseq directory to use.")
@@ -91,7 +103,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	if *indent > 0 && *editMode {
+	// Check if -i was explicitly provided (regardless of its value)
+	iExplicitlySet := false
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == "i" {
+			iExplicitlySet = true
+		}
+	})
+	if iExplicitlySet && *editMode {
 		fmt.Fprintln(os.Stderr, "Error: -i is incompatible with edit mode (-E). Use -a with -i for indented appending.")
 		os.Exit(1)
 	}
@@ -130,8 +149,9 @@ func main() {
 		}
 	}
 
-	// When called with no flags and no content, default to edit mode (equivalent to -E)
-	if flag.NFlag() == 0 && *apnd == "" {
+	// When called with no flags and no content, or with selector flags and no content,
+	// default to edit mode (equivalent to -E).
+	if (flag.NFlag() == 0 || hasSelectorFlag()) && *apnd == "" {
 		*editMode = true
 	}
 


### PR DESCRIPTION
`lsq "hello"` <- appends "hello"
`lsq -a "hello"` <- still appends "hello" (old)
`echo "hello" | lsq` <- appends "hello"
`echo "hello" | lsq -A` <- still appends "hello" (old)
`lsq -E` <- launches $EDITOR
`lsq` (no parameters) <- still launches $EDITOR (old)

Addresses #74 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This update shifts `lsq`’s default behavior from edit mode to append mode whenever content is provided (arguments and piped STDIN), while preserving the original behavior of launching `$EDITOR` when no parameters/content are given. It also introduces a dedicated `-E` flag for edit mode and updates option/usage documentation accordingly.

## Changelog

### Added
- `-E` flag to explicitly enter edit mode
- Ability to use piped STDIN as append content even without `-A`
- Validation error when `-i` is used together with `-E`

### Changed
- Calling `lsq "hello"` now appends by default (edit mode is no longer the default when content is provided)
- Piped input via `echo "hello" | lsq` now appends by default (previously required `-A`)
- `-a`/`-A` are no longer required to enable append mode when content is present
- Positional free arguments are collected as append content when no explicit `-a`/`-A` content is provided
- `lsq` with no parameters and no content still launches `$EDITOR` (edit mode default preserved for this case)
- `-p` editor-launch logic now depends on edit mode (`-E`) rather than append-flag conditions
- Documentation updated to reflect `-E`, default append semantics, and the incompatibility of `-i` with `-E`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->